### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM golang:alpine AS build
+WORKDIR /app
+COPY . /app
+RUN apk add --update-cache yarn make gcc libc-dev && \
+    rm -rf /var/cache/apk/* && \
+    make dist
+
+FROM alpine:latest
+ENV DOIT_DATABASE="/data/doit.db" \
+    DOIT_HOST="0.0.0.0" \
+    DOIT_PORT="8443" \
+    DOIT_MAILFROM="doit@example.com" \
+    DOIT_MAILHOST="localhost:25" \
+    DOIT_TLS="false" \
+    DOIT_TLSCERT="/data/server.crt" \
+    DOIT_TLSKEY="/data/server.key"
+
+WORKDIR /
+COPY --from=build /app/doit.tar.gz /
+COPY entrypoint.sh /
+RUN apk add --update-cache openssl && \
+    rm -rf /var/cache/apk/* && \
+    addgroup -g 1000 doit && \
+    adduser -Ss /bin/false -u 1000 -G doit -h /doit doit && \
+    tar xvf /doit.tar.gz && \
+    rm /doit.tar.gz && \
+    mkdir /data && \
+    chown 1000:1000 /doit && \
+    chmod 755 /entrypoint.sh
+
+EXPOSE $DOIT_PORT
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,9 @@ if [ ! -f $DOIT_TLSCERT ]; then
   openssl req -new -newkey rsa:2048 -days 3650 -nodes -x509 -keyout $DOIT_TLSKEY -out $DOIT_TLSCERT -subj "/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=www.example.com"
 fi
 
+# needed as doit looks for ./dist
+cd /doit
 # Run
-/doit/doit -hostport $DOIT_HOST:$DOIT_PORT -mailfrom $DOIT_MAILFROM -database $DOIT_DATABASE -tlscert $DOIT_TLSCERT -tlskey $DOIT_TLSKEY
+./doit -hostport $DOIT_HOST:$DOIT_PORT -mailfrom $DOIT_MAILFROM -database $DOIT_DATABASE -tlscert $DOIT_TLSCERT -tlskey $DOIT_TLSKEY
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+if ! touch /data/.verify_access; then
+  log "ERROR: /data doesn't seem to be writable. Please make sure attached directory is writable by uid=$(id -u)"
+  exit 2
+fi
+# Remove test-file
+rm /data/.verify_access || true
+
+# If we don't have a TLSCERT we generate a simple self-signed one
+if [ ! -f $DOIT_TLSCERT ]; then
+  echo "INFO: $DOIT_TLSCERT not found, generating self signed certificate"
+  openssl req -new -newkey rsa:2048 -days 3650 -nodes -x509 -keyout $DOIT_TLSKEY -out $DOIT_TLSCERT -subj "/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=www.example.com"
+fi
+
+# Run
+/doit/doit -hostport $DOIT_HOST:$DOIT_PORT -mailfrom $DOIT_MAILFROM -database $DOIT_DATABASE -tlscert $DOIT_TLSCERT -tlskey $DOIT_TLSKEY
+
+


### PR DESCRIPTION
Simple Dockerfile for building doit, configuration set by
overriding environment specified in Dockerfile.

During startup, if tlscert/key is missing a simple self-signed
cert will be generated.

/data used for the database as default, pass in as Volume to save
database between container upgrades.

Ex:
```
$ docker build -t stone/doit .
$ mkdir /tmp/data
$ docker run -it --rm -v /tmp/data:/data -p 8443:8443 stone/doit
```
