### PR TITLE
feat: Remove window reload on periodcalUpdate

### DIFF
--- a/frontend/src/components/ToDoList.vue
+++ b/frontend/src/components/ToDoList.vue
@@ -693,11 +693,6 @@ export default {
                        if (data == "update") {
                            that.selectList(that.activelist);
                        }
-
-                       if (that.errorText != "") {
-                           that.errorText = "";
-                           window.location.reload();
-                       }
                    },
                    error: that.handleError
             });


### PR DESCRIPTION
Remove unnecessary window reload on `periodcalUpdate`. 

Before this update, when going through a low-signal area, the page would try and refresh and break since there wouldn't be enough service to load it fully. This fixes that issue. 